### PR TITLE
Fix broken link to 'Client hooks via phx-hook'

### DIFF
--- a/guides/client/js-interop.md
+++ b/guides/client/js-interop.md
@@ -17,7 +17,7 @@ except for the following LiveView specific options:
     a literal object or closure returning an object. When a closure is provided,
     the function receives the view's element.
   * `hooks` – a reference to a user-defined hooks namespace, containing client
-    callbacks for server/client interop. See the [Client hooks](#client-hooks)
+    callbacks for server/client interop. See the [Client hooks](#client-hooks-via-phx-hook)
     section below for details.
   * `uploaders` – a reference to a user-defined uploaders namespace, containing
     client callbacks for client-side direct-to-cloud uploads. See the


### PR DESCRIPTION
The link on line 20 for Client Hooks directs to a non-existent heading, I am assuming that the correct heading to navigate to is 'Client hooks via `phx-hook`' on line 124.